### PR TITLE
Lock mysql version to 5.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mysql:
-    image: mysql
+    image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:


### PR DESCRIPTION
We should lock down mysql version to prevent the following error which happens when using `mysql:8` 

```Waiting for MySQL server to answer..Got error: Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory```

Because of this issue:
https://github.com/passbolt/passbolt_docker/issues/103

It tries to load the latest version (now version 8) if we do not specify a version